### PR TITLE
Relax dependency on `composite_primary_keys` to support Rails v6

### DIFF
--- a/data-anonymization.gemspec
+++ b/data-anonymization.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency('composite_primary_keys', '~> 11')
+  gem.add_dependency('composite_primary_keys', '>= 11')
   gem.add_dependency('rgeo', '~> 0.5')
   gem.add_dependency('rgeo-geojson', '~> 0.4')
   gem.add_dependency('powerbar', '~> 1.0')


### PR DESCRIPTION
composite_primary_keys v12 has support for Rails v6. By relaxing this dependency we prevent this dependency from blocking the upgrade.